### PR TITLE
Update Add GitHub Action Checking that Zstd Runs Successfully Under CET

### DIFF
--- a/.github/workflows/dev-short-tests.yml
+++ b/.github/workflows/dev-short-tests.yml
@@ -407,7 +407,7 @@ jobs:
         echo 0 | sudo tee /proc/sys/kernel/yama/ptrace_scope
     - name: Run Under SDE
       run: |
-        sde-external-9.0.0-2021-11-07-lin/sde -tgl -cet-endbr-exe -cet-stderr -cet-abort -- ./zstd -b3
+        sde-external-9.0.0-2021-11-07-lin/sde -cet -cet-raise 0 -cet-endbr-exe -cet-stderr -cet-abort -- ./zstd -b3
 
 
 

--- a/.github/workflows/dev-short-tests.yml
+++ b/.github/workflows/dev-short-tests.yml
@@ -390,6 +390,27 @@ jobs:
         DIR
         .\fuzzer.exe -T2m
 
+  intel-cet-compatibility:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build Zstd
+      run: |
+        make -j zstd V=1
+        readelf -n zstd
+    - name: Get Intel SDE
+      run: |
+        curl -LO https://downloadmirror.intel.com/684899/sde-external-9.0.0-2021-11-07-lin.tar.xz
+        tar xJvf sde-external-9.0.0-2021-11-07-lin.tar.xz
+    - name: Configure Permissions
+      run: |
+        echo 0 | sudo tee /proc/sys/kernel/yama/ptrace_scope
+    - name: Run Under SDE
+      run: |
+        sde-external-9.0.0-2021-11-07-lin/sde -tgl -cet-endbr-exe -cet-stderr -cet-abort -- ./zstd -b3
+
+
+
 # This test currently fails on Github Actions specifically.
 # Possible reason : TTY emulation.
 # Note that the same test works fine locally and on travisCI.

--- a/lib/decompress/huf_decompress_amd64.S
+++ b/lib/decompress/huf_decompress_amd64.S
@@ -303,7 +303,8 @@ HUF_decompress4X1_usingDTable_internal_bmi2_asm_loop:
     movq 16(%rsp), %ip3
 
     /* Re-compute olimit */
-    jmp .L_4X1_compute_olimit
+    lea .L_4X1_compute_olimit(%rip), %rax
+    jmp *%rax
 
 #undef GET_NEXT_DELT
 #undef DECODE_FROM_DELT
@@ -535,7 +536,8 @@ HUF_decompress4X2_usingDTable_internal_bmi2_asm_loop:
 
     cmp %op3, 48(%rsp)
     ja .L_4X2_loop_body
-    jmp .L_4X2_compute_olimit
+    lea .L_4X2_compute_olimit(%rip), %rax
+    jmp *%rax
 
 #undef DECODE
 #undef RELOAD_BITS


### PR DESCRIPTION
Pass "-cet -cet-raise 0", instead of "-tgl", to SDE.